### PR TITLE
Add Flathub download links

### DIFF
--- a/_includes/downloadlatest.md
+++ b/_includes/downloadlatest.md
@@ -7,6 +7,8 @@
 <ul><li><a href="https://github.com/codereader/DarkRadiant/releases/download/{{ site.dr_latest_ver }}/DarkRadiant.{{ site.dr_latest_ver }}.app.zip">DarkRadiant.{{ site.dr_latest_ver }}.app.zip</a></li></ul>
 <h3>Debian / Ubuntu / Kubuntu:</h3>
 <p>Use <a href="https://launchpad.net/~orbweaver/+archive/ubuntu/darkradiant">OrbWeaver's PPA</a>, or a <a href="https://packages.debian.org/sid/darkradiant">darkradiant package</a> for Debian, which is usually available after some time in Ubuntu as well.</p>
+<h3>Linux - All Distributions</h3>
+<p>Download the Flatpak version from <a href="https://flathub.org/apps/details/net.darkradiant.DarkRadiant">Flathub</a>, or search for it in Discover or GNOME Software.</p>
 <h3>Compile from Source:</h3>
 <p>See the <a href="https://wiki.thedarkmod.com/index.php?title=DarkRadiant_-_Compilation_Guide">Compilation Guide</a> on our Wiki to build DarkRadiant fresh from its sources.</p>
 </div>

--- a/download.md
+++ b/download.md
@@ -80,6 +80,7 @@ title: DarkRadiant Downloads
       <ul>
         <li>Get it from <a href="https://launchpad.net/~orbweaver/+archive/ubuntu/darkradiant">OrbWeaver's PPA</a></li>
         <li>or search the <a href="https://packages.debian.org/sid/darkradiant">Debian Packages</a> (maintained by the Debian Games Group)</li>
+        <li>or download the Flatpak version from <a href="https://flathub.org/apps/details/net.darkradiant.DarkRadiant">Flathub</a></li>
         <li>or <a href="source.html">Compile from source</a></li>
       </ul>
     </p>


### PR DESCRIPTION
Added to both the "latest download" sidebar and the 3.3.0 release section